### PR TITLE
Add express rate limiting and file path input sanitization

### DIFF
--- a/self-hosting-example/package.json
+++ b/self-hosting-example/package.json
@@ -12,7 +12,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "express": "^4.16.2"
+    "express": "^4.16.2",
+    "express-rate-limit": "^7.1.5"
   },
   "devDependencies": {
     "node-fetch": "2.6.7",

--- a/self-hosting-example/server.js
+++ b/self-hosting-example/server.js
@@ -1,20 +1,33 @@
 const express = require('express');
+const rateLimit = require('express-rate-limit');
 const app = express();
 const path = require('path');
 
 const port = process.env.PORT || 5555;
 
+// Disable X-Powered-By header to hide Express framework information
+app.disable('x-powered-by');
+
+// Rate limiting configuration to prevent DoS attacks
+const fileEndpointLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+  message: 'Too many requests from this IP, please try again later.',
+  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+});
+
 app.use(express.static('public'));
 
-// For the demo
-app.get('/manifest', (req, res) => {
+// For the demo - with rate limiting to prevent DoS attacks
+app.get('/manifest', fileEndpointLimiter, (req, res) => {
     res.sendFile(path.join(__dirname, 'public', 'app.json'));
 });
-// For the demo
-app.get('/app', (req, res) => {
+// For the demo - with rate limiting to prevent DoS attacks
+app.get('/app', fileEndpointLimiter, (req, res) => {
     res.sendFile(path.join(__dirname, 'index.html'));
 });
-app.get('/launch', (req, res) => {
+app.get('/launch', fileEndpointLimiter, (req, res) => {
     res.sendFile(path.join(__dirname, 'launch.html'));
 })
 


### PR DESCRIPTION
Self-hosting example triggered a handful of medium-severity vulnerabilities:

- Removed "X-Powered-By" header from express app
- Added basic rate limiting logic for express GET routes using express-limit
- Sanitized file paths in download-assets.js to prevent "path traversal" vulns